### PR TITLE
feat: Add reset button for burndown chart history

### DIFF
--- a/app/api/stream-data/route.ts
+++ b/app/api/stream-data/route.ts
@@ -77,6 +77,14 @@ export async function GET() {
 export async function POST(request: Request) {
     try {
         const body = await request.json();
+
+        // Handle specific actions first
+        if (body.action === 'reset_burndown_history') {
+            streamData.burndown.entries = [];
+            // Return the updated data immediately
+            return NextResponse.json(streamData);
+        }
+
         const {
             scoreLabel,
             scoreValue,

--- a/app/control-panel/page.tsx
+++ b/app/control-panel/page.tsx
@@ -371,6 +371,27 @@ const ControlPanelPage: React.FC = () => {
             handleTriggerEffect('BUBBLE');
         }
     };
+
+    const handleResetBurndownHistory = async () => {
+        setStatus('loading');
+        try {
+            const res = await axios.post('/api/stream-data', {
+                action: 'reset_burndown_history',
+            });
+
+            if (res.status === 200) {
+                const updatedData = res.data as StreamData;
+                setBurndownEntriesText(updatedData.burndown.entries.join('\n'));
+                setStatus('success');
+            } else {
+                setStatus('error');
+            }
+        } catch (error) {
+            setStatus('error');
+        } finally {
+            setTimeout(() => setStatus('idle'), 2000);
+        }
+    };
     
     const StatusIndicator = () => {
         switch (status) {
@@ -421,6 +442,11 @@ const ControlPanelPage: React.FC = () => {
                             <TextField label="フィールド名" value={burndownLabel} onChange={(e) => setBurndownLabel(e.target.value)} fullWidth margin="normal" variant="outlined" multiline rows={2} />
                             <TextField label="目標値" type="number" value={burndownTargetValue} onChange={(e) => setBurndownTargetValue(Number(e.target.value))} fullWidth margin="normal" variant="outlined" />
                             <TextField label="獲得ポイント履歴 (1行に1つ)" multiline rows={10} value={burndownEntriesText} onChange={(e) => setBurndownEntriesText(e.target.value)} fullWidth margin="normal" variant="outlined" helperText="試合で獲得したポイントを改行区切りで入力します。" />
+                            <Box sx={{mt: 2, display: 'flex', justifyContent: 'flex-end'}}>
+                                <Button variant="outlined" color="error" onClick={handleResetBurndownHistory}>
+                                    履歴をリセット
+                                </Button>
+                            </Box>
                         </Paper>
                     )}
 


### PR DESCRIPTION
This pull request adds a reset button to the burndown chart history in the control panel.

Fixes #7