### PR TITLE
ci: GitHub ActionsのCIワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI/Test
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+      - staging
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Lint
+        run: npm run lint
+
+  test:
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm run test:coverage


### PR DESCRIPTION
Issue #10 に基づき、GitHub Actionsを使用したCI（継続的インテグレーション）ワークフローを追加しました。

## ✨ 主な変更点
- `main`ブランチへのpush、および`main`または`staging`ブランチへのプルリクエスト時にワークフローが実行されます。
- `lint`ジョブでESLintによるコードチェックを行います。
- `test`ジョブでVitestによる単体テストとカバレッジ計測（`npm run test:coverage`）を実行します。

これにより、コードの品質と信頼性が自動的に保証されるようになります。

Closes #10
