### PR TITLE
fix: バーンダウンオーバーレイが自動更新されない問題を修正

### DIFF
--- a/app/api/stream-data/route.ts
+++ b/app/api/stream-data/route.ts
@@ -28,6 +28,7 @@ export interface StreamData {
         timestamp: number;
     } | null;
     burndown: BurndownData; // バーンダウンチャートのデータを追加
+    revision: number; // For forcing re-renders in clients
 }
 
 // データを一時的にインメモリで保持するストア (本番ではDBが必要です)
@@ -68,6 +69,7 @@ export const getInitialStreamData = (): StreamData => ({
         targetValue: 50000,
         entries: [],
     },
+    revision: 0, // Initialize revision
 });
 
 let streamData: StreamData = getInitialStreamData();
@@ -125,6 +127,7 @@ export async function POST(request: Request) {
             // lastEventがbodyに含まれていれば更新、そうでなければ元の値を維持
             lastEvent: 'lastEvent' in body ? lastEvent : streamData.lastEvent,
             burndown: burndown ?? streamData.burndown,
+            revision: streamData.revision + 1, // Increment revision on every update
         };
 
         return NextResponse.json(streamData);

--- a/app/burndown-overlay/page.tsx
+++ b/app/burndown-overlay/page.tsx
@@ -57,7 +57,7 @@ const BurndownOverlayPage: React.FC = () => {
                 position: 'relative',
             }}
         >
-            <BurndownChart data={burndown} />
+            <BurndownChart key={data.revision} data={burndown} />
             <FireworksEffect trigger={hasReachedZero} />
         </div>
     );


### PR DESCRIPTION
Issue #8 に基づき、バーンダウンオーバーレイが自動で更新されない問題を修正しました。

## ✨ 主な変更点
- APIの`StreamData`に`revision`カウンターを追加しました。
- `POST`リクエストでデータが更新されるたびに`revision`をインクリメントします。
- `BurndownOverlayPage`で`BurndownChart`コンポーネントに`revision`を`key`として渡すことで、データが更新されるたびにコンポーネントが強制的に再マウントされるようにしました。

これにより、`BurndownChart`が最新のデータで適切に更新されることが保証されます。

Closes #8
